### PR TITLE
fix: support ArrayLike object with prefer-native-array-methods rule

### DIFF
--- a/lib/rules/prefer-native-array-methods.js
+++ b/lib/rules/prefer-native-array-methods.js
@@ -43,19 +43,11 @@ module.exports = {
                 "use Array.prototype.{{nativeApi}} instead of {{deprecatedApi}}.",
               data: { nativeApi, deprecatedApi },
               fix(fixer) {
-                const sourceCode = context.getSourceCode();
-                const [list] = node.arguments;
                 return [
                   fixer.replaceText(
                     node.callee,
-                    sourceCode.getText(list) +
-                      "." +
-                      nativeApi.replace(/.*\./, "")
-                  ),
-                  fixer.removeRange([
-                    node.arguments[0].start,
-                    node.arguments[1].start
-                  ])
+                    "Array.prototype." + nativeApi + ".call"
+                  )
                 ];
               }
             });

--- a/tests/lib/rules/prefer-native-array-methods.js
+++ b/tests/lib/rules/prefer-native-array-methods.js
@@ -8,27 +8,29 @@ new RuleTester().run("prefer-native-apis", rule, {
   invalid: [
     {
       code: "goog.array.forEach(list, function(el) { return el })",
-      output: "list.forEach(function(el) { return el })",
+      output: "Array.prototype.forEach.call(list, function(el) { return el })",
       errors: ["use Array.prototype.forEach instead of goog.array.forEach."]
     },
     {
       code: "goog.array.forEach(this.foo, function(el) { return el })",
-      output: "this.foo.forEach(function(el) { return el })",
+      output:
+        "Array.prototype.forEach.call(this.foo, function(el) { return el })",
       errors: ["use Array.prototype.forEach instead of goog.array.forEach."]
     },
     {
       code: "goog.array.forEach(this.foo, function(el) { return el }, ctx)",
-      output: "this.foo.forEach(function(el) { return el }, ctx)",
+      output:
+        "Array.prototype.forEach.call(this.foo, function(el) { return el }, ctx)",
       errors: ["use Array.prototype.forEach instead of goog.array.forEach."]
     },
     {
       code: "goog.array.map(list, function(el) { return el })",
-      output: "list.map(function(el) { return el })",
+      output: "Array.prototype.map.call(list, function(el) { return el })",
       errors: ["use Array.prototype.map instead of goog.array.map."]
     },
     {
       code: "goog.array.some(list, function(el) { return el })",
-      output: "list.some(function(el) { return el })",
+      output: "Array.prototype.some.call(list, function(el) { return el })",
       errors: ["use Array.prototype.some instead of goog.array.some."]
     }
   ]


### PR DESCRIPTION
Fix #1 